### PR TITLE
Add connect benchmark.

### DIFF
--- a/benchmark/connect.js
+++ b/benchmark/connect.js
@@ -1,0 +1,43 @@
+/*!
+ * kick.js - benchmark/connect.js
+ * 
+ * !!! npm install connect@1.8.6
+ * 
+ * Copyright(c) 2012 fengmk2 <fengmk2@gmail.com>
+ * MIT Licensed
+ */
+
+/**
+ * Module dependencies.
+ */
+
+var connect = require('connect');
+var profiler = require('v8-profiler');
+var http = require('http');
+
+var app = module.exports = connect();
+app.use(function(req, res, next) {
+  req.hello = 'hello world';
+  next();
+});
+
+app.use(connect.router(function(app) {
+  app.get('/', function(req, res, next) {
+    res.end(req.hello);
+  });
+
+  app.get('/user/:userid', function(req, res, next) {
+    res.end(req.params.userid + req.hello);
+  });
+}));
+
+setInterval(function() {
+  profiler.startProfiling('flow');
+  setTimeout(function() {
+    profiler.stopProfiling('flow');
+  }, 100);
+}, 1000);
+
+if (!module.parent) {
+  app.listen(3000);
+}


### PR DESCRIPTION
My '搓' mac air result: `kick.js` is better than `connect`
## /benchmark/connect.js

``` bash
GET:/
    done:100000
    200 OK: 100000
    rps: 1998
    response: 1ms(min)  292ms(max)  7ms(avg)
```
## /benchmark/app.js

``` bash
GET:/
    done:100000
    200 OK: 100000
    rps: 2536
    response: 1ms(min)  191ms(max)  5ms(avg)
```
